### PR TITLE
[Issue-96] Rewrite Dockerfile and upgrade Spark2.3.x to Spark2.4.x

### DIFF
--- a/doc/API_doc.md
+++ b/doc/API_doc.md
@@ -6,7 +6,7 @@ QSQL supports called API directly by other applications to execute queries. If y
 
 ``` java
 <dependency>
-		<groupId>com.qihoo.qsql</groupId>
+        <groupId>com.qihoo.qsql</groupId>
         <artifactId>qsql-core</artifactId>
         <version>${project.version}</version>
 </dependency>

--- a/doc/API文档.md
+++ b/doc/API文档.md
@@ -6,7 +6,7 @@ QSQL支持在其他应用中通过API执行查询，如果你有类似场景，�
 
 ``` java
 <dependency>
-		<groupId>com.qihoo.qsql</groupId>
+        <groupId>com.qihoo.qsql</groupId>
         <artifactId>qsql-core</artifactId>
         <version>${project.version}</version>
 </dependency>

--- a/docker/0.6/Dockerfile
+++ b/docker/0.6/Dockerfile
@@ -4,24 +4,23 @@ MAINTAINER francis francis@francisdu.com
 
 USER root
 
-# Install dependency 
-RUN yum update -y && yum install -y \
-    wget openssh vim \
+# Install dependencies
+RUN yum update -y && yum install -y wget openssh vim \
     openssh-clients java-1.8.0-openjdk \
     java-1.8.0-openjdk-devel  java-1.8.0-openjdk-headless
 
-# Download QlickSQL package
+# Download Qlick SQL package
 RUN  wget https://github.com/Qihoo360/Quicksql/releases/download/release-0.6/qsql-0.6.tar.gz &&  \
      tar -xzvf qsql-0.6.tar.gz -C /usr/local
 
 # Download Spark package
-RUN wget http://mirrors.tuna.tsinghua.edu.cn/apache/spark/spark-2.3.3/spark-2.3.3-bin-hadoop2.7.tgz &&  \
-    tar -xzvf spark-2.3.3-bin-hadoop2.7.tgz -C /usr/local
+RUN wget http://mirrors.tuna.tsinghua.edu.cn/apache/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz &&  \
+    tar -xzvf spark-2.4.4-bin-hadoop2.7.tgz -C /usr/local
 
 # Setting environments
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.212.b04-0.el7_6.x86_64
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk
 ENV QSQL_HOME /usr/local/qsql-0.6
-ENV SPARK_HOME /usr/local/spark-2.3.3-bin-hadoop2.7
+ENV SPARK_HOME /usr/local/spark-2.4.4-bin-hadoop2.7
 ENV PATH $JAVA_HOME/bin:$SPARK_HOME/bin:$SPARK_HOME/sbin:$QSQL_HOME/bin:$PATH
 RUN export PATH QSQL_HOME SPARK_HOME
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,30 +1,27 @@
 # Dockerfile for QuickSQL
 
-### [Dokerhub Address](https://hub.docker.com/r/francisdu/quicksql)
+[Docker Image](https://hub.docker.com/r/francisdu/quicksql)
 
-## Usage:(Centos)
-#### Step 1:
+## Easy to use:(Based on Centos7)
+
+- Step 1:
 Install Docker service : `yum update -y && yum intall docker -y`
-#### Step 2:
-Run QuickSQL : ` docker run -d --name quicksql francisdu/quicksql`
-#### Step 3:
-Open a terminal : `docker exec -it [CONTAINER NAME / ID] /bin/bash`
-#### Step 4:
-Run a example : `$QSQL_HOME/bin/run-example com.qihoo.qsql.CsvJoinWithEsExample`
+
+- Step 2:
+Run Quick SQL image: ` docker run -d --name quicksql francisdu/quicksql`
+
+- Step 3:
+Open terminal : `docker exec -it [CONTAINER NAME / ID] /bin/bash`
+
+- Step 4:
+Run example : `$QSQL_HOME/bin/run-example com.qihoo.qsql.CsvJoinWithEsExample`
 
 ## Installation location:
 
-`QSQL_HOME = /usr/local/qsql-0.6`
+`QSQL_HOME = /usr/local/qsql`
 
-`Spark_HOME = /usr/local/spark-2.3.3-bin-hadoop2.7`
+`Spark_HOME = /usr/local/spark`
 
 ## Documents
-[架构介绍](https://github.com/Qihoo360/Quicksql/blob/master/doc/README%E6%96%87%E6%A1%A3.md)
 
-[部署文档](https://github.com/Qihoo360/Quicksql/blob/master/doc/BUILD%E6%96%87%E6%A1%A3.md)
-
-[命令行](https://github.com/Qihoo360/Quicksql/blob/master/doc/CLI%E6%96%87%E6%A1%A3.md)
-
-[JDBC](https://github.com/Qihoo360/Quicksql/blob/master/doc/JDBC%E6%96%87%E6%A1%A3.md)
-
-[API](https://github.com/Qihoo360/Quicksql/blob/master/doc/API%E6%96%87%E6%A1%A3.md)
+[架构介绍](../doc/README文档.md) | [部署文档](../doc/BUILD文档.md) | [命令行文档](../doc/CLI文档.md) | [JDBC文档](../doc/JDBC文档.md) | [API文档](../doc/API文档.md)

--- a/docker/latest/Dockerfile
+++ b/docker/latest/Dockerfile
@@ -1,0 +1,36 @@
+From maven:3.6.2-jdk-8-openj9
+
+MAINTAINER francis francis@francisdu.com
+
+USER root
+
+# Install dependencies
+RUN apt-get update -y&& apt-get install -y ssh vim wget git
+
+# Build Qlick SQL source code
+RUN cd ~ && git clone https://github.com/Qihoo360/Quicksql.git && \
+    cd Quicksql && mvn clean package -DskipTests
+
+# Unzip the Qlick SQL package
+RUN cd ~/Quicksql && tar -xzvf target/$(awk -v RS='\r\n' '/<qsql.release>[^<]+<\/qsql.release>/{gsub(/<qsql.release>|<\/qsql.release>/,"",$1);printf $1;exit;}'  ~/Quicksql/pom.xml).tar.gz -C /usr/local && \
+    ln -s /usr/local/$(awk -v RS='\r\n' '/<qsql.release>[^<]+<\/qsql.release>/{gsub(/<qsql.release>|<\/qsql.release>/,"",$1);printf $1;exit;}'  ~/Quicksql/pom.xml) /usr/local/qsql
+
+# Download Spark package
+RUN cd ~ && wget http://mirrors.tuna.tsinghua.edu.cn/apache/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz &&  \
+    tar -xzvf spark-2.4.4-bin-hadoop2.7.tgz -C /usr/local && \
+    ln -s /usr/local/spark-2.4.4-bin-hadoop2.7 /usr/local/spark
+
+# TODO : Add other services such as ES,Flink,etc...
+
+# Clean up source code and installation packages and dependencies, etc.
+RUN rm -rf ~/Quicksql ~/.m2 ~/spark*
+
+# Setting environments
+ENV QSQL_HOME /usr/local/qsql
+ENV SPARK_HOME /usr/local/spark
+ENV PATH $SPARK_HOME/bin:$SPARK_HOME/sbin:$QSQL_HOME/bin:$PATH
+RUN export PATH QSQL_HOME SPARK_HOME
+
+WORKDIR /usr/local/qsql
+
+EXPOSE 4040 8080


### PR DESCRIPTION
Description : https://github.com/Qihoo360/Quicksql/issues/96

Improved : 
- Modified the Spark version : The download link for Spark2.3 in the old version of Dockerfile has expired.
- Rewrite Dockerfile : The new Dockerfile allows users to build from the latest source code.
- Rebuilt the Docker image of both : [Build successful](https://hub.docker.com/r/francisdu/quicksql/builds).
  - [release-0.6](https://hub.docker.com/r/francisdu/quicksql/tags)
  - [latest](https://hub.docker.com/r/francisdu/quicksql/tags)