### PR TITLE
Bump mysql-connector-java from 5.1.20 to 8.0.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-scm-provider.version>1.9.5</maven-scm-provider.version>
         <mockito.version>2.21.0</mockito.version>
-        <mysql-driver.version>5.1.20</mysql-driver.version>
+        <mysql-driver.version>8.0.20</mysql-driver.version>
         <hive-driver.version>1.2.1</hive-driver.version>
         <natty.version>0.13</natty.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
update the version of mysql-driver-java to 8.0.20 in pom file located in project root path for the exception which is about [java.lang.ClassCastException: java.math.BigInteger cannot be cast to java.lang.Long]

## I'm submitting a...

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Added tests
- [ ] Documentation
- [ ] Other (`Please describe in detail here`)

## Checklist

- [x] Commit Messages follow the [Conventional Commits]
```
fix: update version of the mysql-driver-java to 8.0.20

update the version of mysql-driver-java to 8.0.20 in pom file located in project root path for the exception which is about [java.lang.ClassCastException: java.math.BigInteger cannot be cast to java.lang.Long]

```
- [ ] Tests for the changes have been added

## Description

```
update the version of mysql-driver-java to 8.0.20 in pom file located in project root path for the exception which is about [java.lang.ClassCastException: java.math.BigInteger cannot be cast to java.lang.Long]
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
