### PR TITLE
fix: update error parameter from 3 to 2 in tableNameCollector in case of `A.A.A`

### DIFF
--- a/core/src/main/java/com/qihoo/qsql/plan/TableNameCollector.java
+++ b/core/src/main/java/com/qihoo/qsql/plan/TableNameCollector.java
@@ -190,7 +190,7 @@ public class TableNameCollector implements SqlVisitor<QueryTables> {
 
     private QueryTables validateTableName(QueryTables tableNames) {
         for (String tableName : tableNames.tableNames) {
-            if (tableName.split("\\.", -1).length > 3) {
+            if (tableName.split("\\.", -1).length > 2) {
                 throw new ParseException("Qsql only support structure like dbName.tableName,"
                     + " and there is a unsupported tableName here: " + tableName);
             }


### PR DESCRIPTION
## I'm submitting a...

- [x] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Added tests
- [ ] Documentation
- [ ] Other (`Please describe in detail here`)

## Checklist

- [x] Commit Messages follow the [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0-beta.4/) pattern
  - A feature commit message is prefixed "feat:"
  - A bug fix commit message is prefixed "fix:"
- [x] Tests for the changes have been added

## Description
* close #280 

Current error parameter in `validateTableName` can not throw exception in case of `A.A.A`, see `testParseSingleBdNameAndTableNameWithError` and ` testParseSingleBdNameAndTableNameWithError2`. So I change it to `2` from `3`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
