### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -78,7 +76,7 @@
         <hydromatic-resource.version>0.6</hydromatic-resource.version>
         <hydromatic-toolbox.version>0.3</hydromatic-toolbox.version>
         <hydromatic-tpcds.version>0.4</hydromatic-tpcds.version>
-        <jackson.version>2.6.5</jackson.version>
+        <jackson.version>2.12.6.1</jackson.version>
         <jackson.core.version>2.10.0</jackson.core.version>
         <janino.version>3.0.11</janino.version>
         <java-diff.version>1.1.2</java-diff.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.6.5
- [CVE-2019-14540](https://www.oscs1024.com/hd/CVE-2019-14540)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.6.5 to 2.12.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS